### PR TITLE
Fix for missing tenantId from subdomain

### DIFF
--- a/lib/tenancy-core.module.ts
+++ b/lib/tenancy-core.module.ts
@@ -185,7 +185,7 @@ export class TenancyCoreModule implements OnApplicationShutdown {
         // Pull the tenant id from the subdomain
         if (isTenantFromSubdomain) {
 
-            return this.getTenantFromSubdomain(isFastifyAdaptor, req);
+            return this.getTenantFromSubdomain(req);
 
         } else {
             // Validate if tenant identifier token is present
@@ -237,20 +237,12 @@ export class TenancyCoreModule implements OnApplicationShutdown {
      * @returns
      * @memberof TenancyCoreModule
      */
-    private static getTenantFromSubdomain(isFastifyAdaptor: boolean, req: Request) {
-        let tenantId = '';
-        
-        if (isFastifyAdaptor) { // For Fastify
-            const subdomains = this.getSubdomainsForFastify(req);
+    private static getTenantFromSubdomain(req: Request) {
+        const subdomains = this.getSubdomainsForFastify(req);
 
-            if (subdomains instanceof Array && subdomains.length > 0) {
-                tenantId = subdomains[subdomains.length - 1];
-            }
-        } else { // For Express - Default
-            // Check for multi-level subdomains and return only the first name
-            if (req.subdomains instanceof Array && req.subdomains.length > 0) {
-                tenantId = req.subdomains[req.subdomains.length - 1];
-            }
+        let tenantId = '';
+        if (subdomains instanceof Array && subdomains.length > 0) {
+            tenantId = subdomains[subdomains.length - 1];
         }
 
         // Validate if tenant identifier token is present

--- a/tests/e2e/cat-tenancy.spec.ts
+++ b/tests/e2e/cat-tenancy.spec.ts
@@ -22,6 +22,7 @@ describe('CatTenancy', () => {
         const createDto = { name: 'Nest', breed: 'Maine coon', age: 5 };
         request(server)
             .post('/cats')
+            .set('Host', 'cats.localhost:3000')
             .set('X-TENANT-ID', 'cats')
             .send(createDto)
             .expect(201)

--- a/tests/e2e/dog-tenancy.spec.ts
+++ b/tests/e2e/dog-tenancy.spec.ts
@@ -22,6 +22,7 @@ describe('DogTenancy', () => {
         const createDto = { name: 'Charlie', breed: 'Beagle', age: 6 };
         request(server)
             .post('/dogs')
+            .set('Host', 'dogs.localhost:3000')
             .set('X-TENANT-ID', 'dogs')
             .send(createDto)
             .expect(201)

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -8,6 +8,7 @@ import { DogsModule } from './dogs/dogs.module';
     imports: [
         MongooseModule.forRoot('mongodb://localhost:27017/test'),
         TenancyModule.forRoot({
+            isTenantFromSubdomain: true,
             tenantIdentifier: 'X-TENANT-ID',
             options: () => { },
             uri: (tenantId: string) => `mongodb://localhost/test-tenant-${tenantId}`,


### PR DESCRIPTION
Fixes #6 

NestJS doesn't seem to load host subdomains into
`Request.subdomains[]`
so existing logic for reading subdomains was ineffective.

Now using same logic of getting subdomains from
`Request.headers.host`
for both express and fastify.