### PR TITLE
Change tenancy-options uri to Promise<string> or `string

### DIFF
--- a/lib/interfaces/tenancy-options.interface.ts
+++ b/lib/interfaces/tenancy-options.interface.ts
@@ -11,22 +11,22 @@ export interface TenancyModuleOptions extends Record<string, any> {
      * If `true`, tenant id will be extracted from the subdomain
      */
     isTenantFromSubdomain?: boolean;
-    
+
     /**
      * Tenant id will be extracted using the keyword from the request header
      */
     tenantIdentifier?: string;
-    
+
     /**
      * URI for the tenant database
      */
-    uri: (uri: string) => string;
+    uri: (uri: string) => Promise<string> | string;
 
     /**
      * Used for applying custom validations
      */
     validator?: (tenantId: string) => TenancyValidator;
-    
+
     /**
      * Options for the database
      */
@@ -39,7 +39,7 @@ export interface TenancyModuleOptions extends Record<string, any> {
 
     /**
      * Option to create the collections that are mapped to the tenant module
-     * automatically while requesting for the tenant connection for the 
+     * automatically while requesting for the tenant connection for the
      * first time. This option is useful in case on mongo transactions, where
      * transactions doens't create a collection if it does't exist already.
      */
@@ -48,8 +48,8 @@ export interface TenancyModuleOptions extends Record<string, any> {
 
 /**
  * For creating options dynamically
- * 
- * To use this the class implementing `TenancyOptionsFactory` should 
+ *
+ * To use this the class implementing `TenancyOptionsFactory` should
  * implement the method `createTenancyOptions` under it.
  *
  * @export
@@ -75,7 +75,7 @@ export interface TenancyModuleAsyncOptions extends Pick<ModuleMetadata, 'imports
 /**
  * Tenancy validator interface
  * Note: The implementation controls the validation of the tenant
- * `validate` method will be called by the platform if valdation is set in the 
+ * `validate` method will be called by the platform if valdation is set in the
  * parent application.
  *
  * @export

--- a/lib/tenancy-core.module.ts
+++ b/lib/tenancy-core.module.ts
@@ -34,7 +34,7 @@ export class TenancyCoreModule implements OnApplicationShutdown {
         const connectionMapProvider = this.createConnectionMapProvider();
 
         /* Model Definition Map */
-        const modelDefinitionMapProvider = this.createModelDefinitionMapProvider();       
+        const modelDefinitionMapProvider = this.createModelDefinitionMapProvider();
 
         /* Tenant Context */
         const tenantContextProvider = this.createTenantContextProvider();
@@ -98,7 +98,7 @@ export class TenancyCoreModule implements OnApplicationShutdown {
 
         /* Http Adaptor */
         const httpAdapterHost = this.createHttpAdapterProvider();
-        
+
         /* Tenant Connection */
         const tenantConnectionProvider = {
             provide: TENANT_CONNECTION,
@@ -196,7 +196,7 @@ export class TenancyCoreModule implements OnApplicationShutdown {
             return this.getTenantFromRequest(isFastifyAdaptor, req, tenantIdentifier);
         }
     }
-    
+
     /**
      * Get the Tenant information from the request object
      *
@@ -223,7 +223,7 @@ export class TenancyCoreModule implements OnApplicationShutdown {
         if (this.isEmpty(tenantId)) {
             throw new BadRequestException(`${tenantIdentifier} is not supplied`);
         }
-        
+
         return tenantId;
     }
 
@@ -239,7 +239,7 @@ export class TenancyCoreModule implements OnApplicationShutdown {
      */
     private static getTenantFromSubdomain(isFastifyAdaptor: boolean, req: Request) {
         let tenantId = '';
-        
+
         if (isFastifyAdaptor) { // For Fastify
             const subdomains = this.getSubdomainsForFastify(req);
 
@@ -283,7 +283,7 @@ export class TenancyCoreModule implements OnApplicationShutdown {
         if (moduleOptions.validator) {
             await moduleOptions.validator(tenantId).validate();
         }
-        
+
         // Check if tenantId exist in the connection map
         const exists = connMap.has(tenantId);
 
@@ -292,7 +292,7 @@ export class TenancyCoreModule implements OnApplicationShutdown {
             const connection = connMap.get(tenantId) as Connection;
 
             if (moduleOptions.forceCreateCollections) {
-                // For transactional support the Models/Collections has exist in the 
+                // For transactional support the Models/Collections has exist in the
                 // tenant database, otherwise it will throw error
                 await Promise.all(
                     Object.entries(connection.models).map(([k, m]) => m.createCollection())
@@ -301,9 +301,10 @@ export class TenancyCoreModule implements OnApplicationShutdown {
 
             return connection;
         }
-        
+
         // Otherwise create a new connection
-        const connection = createConnection(moduleOptions.uri(tenantId), {
+        const uri = await Promise.resolve(moduleOptions.uri(tenantId))
+        const connection = createConnection(uri, {
             useNewUrlParser: true,
             useUnifiedTopology: true,
             ...moduleOptions.options(),
@@ -315,7 +316,7 @@ export class TenancyCoreModule implements OnApplicationShutdown {
             const modelCreated = connection.model(name, schema, collection);
 
             if (moduleOptions.forceCreateCollections) {
-                // For transactional support the Models/Collections has exist in the 
+                // For transactional support the Models/Collections has exist in the
                 // tenant database, otherwise it will throw error
                 await modelCreated.createCollection();
             }
@@ -381,7 +382,7 @@ export class TenancyCoreModule implements OnApplicationShutdown {
             ]
         }
     }
-    
+
     /**
      * Create options providers
      *
@@ -421,7 +422,7 @@ export class TenancyCoreModule implements OnApplicationShutdown {
     private static createAsyncOptionsProvider(
         options: TenancyModuleAsyncOptions,
     ): Provider {
-        if(options.useFactory) {
+        if (options.useFactory) {
             return {
                 provide: TENANT_MODULE_OPTIONS,
                 useFactory: options.useFactory,
@@ -435,7 +436,7 @@ export class TenancyCoreModule implements OnApplicationShutdown {
 
         return {
             provide: TENANT_MODULE_OPTIONS,
-            useFactory: async (optionsFactory: TenancyOptionsFactory) => 
+            useFactory: async (optionsFactory: TenancyOptionsFactory) =>
                 await optionsFactory.createTenancyOptions(),
             inject,
         };


### PR DESCRIPTION
Making 'uri' promise allows for async operations such as fetching
tenant database uri from primary database.
