### PR TITLE
make tenantId optional

### DIFF
--- a/lib/guards/index.ts
+++ b/lib/guards/index.ts
@@ -1,0 +1,1 @@
+export * from './tenant-guard';

--- a/lib/guards/tenant-guard.ts
+++ b/lib/guards/tenant-guard.ts
@@ -1,0 +1,11 @@
+import { CanActivate, ExecutionContext } from '@nestjs/common';
+import { Observable } from 'rxjs';
+
+export class TenantGuard implements CanActivate {
+    constructor(private readonly needsTenant = true) {}
+
+    public canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
+        const request = context.switchToHttp().getRequest();
+        return this.needsTenant && !!request.tenantId;
+    }
+}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,1 +1,2 @@
 export * from './tenancy-types';
+export * from './tenancy-request';

--- a/lib/types/tenancy-request.ts
+++ b/lib/types/tenancy-request.ts
@@ -1,0 +1,5 @@
+import { Request } from 'express';
+
+export interface TenancyRequest extends Request {
+    tenantId?: string;
+}


### PR DESCRIPTION
Re: issue https://github.com/needle-innovision/nestjs-tenancy/issues/27

Allow the tenantId to be optional.

Added `forceCheck` to the module options (default false) to state if the tenant should be checked on initialisation or not.

Added an TenantGuard to be able to specify if a route needs a tenant or not. 

Notes:

- If you want to support optional tenantId, ensure that any validator being implemented checks if tenantId is defined or not.

e.g.
```
public async validate(): Promise<void> {
        if (!this._tenantId) {
            return;
        }
        const exist = await this.tenantModel.exists({ _id: this._tenantId });
        if (!exist) {
            throw new NotFoundException('Tenant not found');
        }
    }
```

- TENANT_CONTEXT or other provided tokens may be undefined if the tenant isn't specified, so protect against them / sanity check them.
