### PR TITLE
Optional tenant id checking based on request route path

### DIFF
--- a/lib/factories/tenancy.factory.ts
+++ b/lib/factories/tenancy.factory.ts
@@ -37,6 +37,11 @@ export const createTenancyProviders = (definitions: ModelDefinition[]): Provider
         providers.push({
             provide: getTenantModelToken(name),
             useFactory(tenantConnection: Connection) {
+                // tenantConnection will be null if route is excluded from tenant Id check,
+                // thus, skipTenantCheck is true
+                if(tenantConnection == null){
+                    return {};
+                }
                 return tenantConnection.models[name] || tenantConnection.model(name, schema, collection);
             },
             inject: [TENANT_CONNECTION],

--- a/lib/interfaces/tenancy-options.interface.ts
+++ b/lib/interfaces/tenancy-options.interface.ts
@@ -28,6 +28,9 @@ export interface TenancyModuleOptions extends Record<string, any> {
      */
     validator?: (tenantId: string) => TenancyValidator;
 
+    /**
+     * Use for bypassing tenant database connection on some routes.
+     */
     skipTenantCheck?: (request: Request) => boolean;
 
     /**
@@ -59,7 +62,7 @@ export interface TenancyModuleOptions extends Record<string, any> {
  * @interface TenancyOptionsFactory
  */
 export interface TenancyOptionsFactory {
-    createTenancyOptions():Promise<TenancyModuleOptions> | TenancyModuleOptions;
+    createTenancyOptions(): Promise<TenancyModuleOptions> | TenancyModuleOptions;
 }
 
 /**

--- a/lib/interfaces/tenancy-options.interface.ts
+++ b/lib/interfaces/tenancy-options.interface.ts
@@ -1,4 +1,5 @@
 import { ModuleMetadata, Type } from '@nestjs/common/interfaces';
+import { Request } from 'express';
 
 /**
  * Options for synchronous setup
@@ -26,6 +27,8 @@ export interface TenancyModuleOptions extends Record<string, any> {
      * Used for applying custom validations
      */
     validator?: (tenantId: string) => TenancyValidator;
+
+    skipTenantCheck?: (request: Request) => boolean;
 
     /**
      * Options for the database

--- a/lib/tenancy-core.module.ts
+++ b/lib/tenancy-core.module.ts
@@ -51,9 +51,8 @@ export class TenancyCoreModule implements OnApplicationShutdown {
                 moduleOptions: TenancyModuleOptions,
                 connMap: ConnectionMap,
                 modelDefMap: ModelDefinitionMap,
-                req: Request
             ): Promise<Connection | undefined> => {
-                return await this.getConnection(tenantId, moduleOptions, connMap, modelDefMap, req);
+                return await this.getConnection(tenantId, moduleOptions, connMap, modelDefMap);
             },
             inject: [
                 TENANT_CONTEXT,
@@ -108,10 +107,9 @@ export class TenancyCoreModule implements OnApplicationShutdown {
                 tenantId: string,
                 moduleOptions: TenancyModuleOptions,
                 connMap: ConnectionMap,
-                modelDefMap: ModelDefinitionMap,
-                req: Request
+                modelDefMap: ModelDefinitionMap
             ): Promise<Connection | undefined> => {
-                return await this.getConnection(tenantId, moduleOptions, connMap, modelDefMap, req);
+                return await this.getConnection(tenantId, moduleOptions, connMap, modelDefMap);
             },
             inject: [
                 TENANT_CONTEXT,
@@ -285,13 +283,12 @@ export class TenancyCoreModule implements OnApplicationShutdown {
         tenantId: string,
         moduleOptions: TenancyModuleOptions,
         connMap: ConnectionMap,
-        modelDefMap: ModelDefinitionMap,
-        req: Request
+        modelDefMap: ModelDefinitionMap
     ): Promise<Connection | undefined> {
-        if(moduleOptions.skipTenantCheck){
-            if(moduleOptions.skipTenantCheck(req) === true){
-                return undefined;
-            }
+        // If the value tenantId is undefined and skipTenantCheck was specified
+        // by the user, assume the route should be skipped.
+        if (tenantId == undefined && moduleOptions.skipTenantCheck) {
+            return undefined;
         }
 
         // Check if validator is set, if so call the `validate` method on it

--- a/lib/tenancy.module.ts
+++ b/lib/tenancy.module.ts
@@ -5,16 +5,17 @@ import { TenancyFeatureModule } from './tenancy-feature.module';
 
 /**
  * Module to help with multi tenancy
- * 
+ *
  * For root configutaion:
  * ```ts
  * TenancyModule.forRoot({
  *    tenantIdentifier: 'X-TenantId',
  *    options: {},
  *    uri: (tenantId: string) => `mongodb://localhost/tenant-${tenantId}`,
+ *    skipTenantCheck: (req) => req.route.path.match(/^\/birds/) != null,
  * })
  * ```
- * 
+ *
  * For root async configuration:
  * ```ts
  * TenancyModule.forRootAsync({
@@ -22,7 +23,7 @@ import { TenancyFeatureModule } from './tenancy-feature.module';
  *    inject: [ConfigService],
  * })
  *```
- * 
+ *
  * For feature configurations:
  * ```ts
  * TenancyModule.forFeature([{ name: 'Account', schema: AccountSchema }])

--- a/tests/e2e/bird-tenancy.spec.ts
+++ b/tests/e2e/bird-tenancy.spec.ts
@@ -1,0 +1,52 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { Server } from 'http';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('Bird Without Tenancy', () => {
+    let server: Server;
+    let app: INestApplication;
+
+    beforeEach(async () => {
+        const module = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+
+        app = module.createNestApplication();
+        server = app.getHttpServer();
+        await app.init();
+    });
+
+    it(`should return created document`, (done) => {
+        const dto = { name: 'Pigeon', breed: 'Columbidae', age: 15 };
+        request(server)
+            .post('/birds')
+            .send(dto)
+            .expect(201)
+            .end((err, { body }) => {
+                expect(body.name).toEqual(dto.name);
+                expect(body.age).toEqual(dto.age);
+                expect(body.breed).toEqual(dto.breed);
+                done();
+            });
+    });
+
+    it(`should return list of birds`, (done) => {
+        const dto = { name: 'Pigeon', breed: 'Columbidae', age: 15 };
+
+        request(server)
+            .get('/birds')
+            .expect(200)
+            .end((err, { body }) => {
+                expect(body[0].name).toEqual(dto.name);
+                expect(body[0].age).toEqual(dto.age);
+                expect(body[0].breed).toEqual(dto.breed);
+                done();
+            });
+    });
+
+    afterEach(async () => {
+        await app.close();
+    });
+});

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -11,9 +11,7 @@ import { DogsModule } from './dogs/dogs.module';
         TenancyModule.forRoot({
             tenantIdentifier: 'X-TENANT-ID',
             options: () => { },
-            skipTenantCheck: (req) => {
-                return req.route.path.match(/^\/birds*/) != null;
-            },
+            skipTenantCheck: (req) => req.route.path.match(/^\/birds*/) != null,
             uri: (tenantId: string) => `mongodb://127.0.0.1:27017/test-tenant-${tenantId}`,
 
         }),

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -1,3 +1,4 @@
+import { BirdsModule } from './birds/birds.module';
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { TenancyModule } from '../../lib';
@@ -6,14 +7,19 @@ import { DogsModule } from './dogs/dogs.module';
 
 @Module({
     imports: [
-        MongooseModule.forRoot('mongodb://localhost:27017/test'),
+        MongooseModule.forRoot('mongodb://127.0.0.1:27017/test'),
         TenancyModule.forRoot({
             tenantIdentifier: 'X-TENANT-ID',
             options: () => { },
-            uri: (tenantId: string) => `mongodb://localhost/test-tenant-${tenantId}`,
+            skipTenantCheck: (req) => {
+                return req.route.path.match(/^\/birds*/) != null;
+            },
+            uri: (tenantId: string) => `mongodb://127.0.0.1:27017/test-tenant-${tenantId}`,
+
         }),
         CatsModule,
         DogsModule,
+        BirdsModule
     ],
 })
 export class AppModule { }

--- a/tests/src/birds/bird.controller.ts
+++ b/tests/src/birds/bird.controller.ts
@@ -1,0 +1,20 @@
+
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { BirdsService } from './birds.service';
+import { CreateBirdDto } from './dto/create-bird.dto';
+import { Bird } from './schemas/bird.schema';
+
+@Controller('birds')
+export class BirdsController {
+    constructor(private readonly service: BirdsService) { }
+
+    @Post()
+    async create(@Body() dto: CreateBirdDto) {
+        return this.service.create(dto);
+    }
+
+    @Get()
+    async findAll(): Promise<Bird[]> {
+        return this.service.findAll();
+    }
+}

--- a/tests/src/birds/birds.module.ts
+++ b/tests/src/birds/birds.module.ts
@@ -1,0 +1,14 @@
+import { BirdsService } from './birds.service';
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { BirdsController } from './bird.controller';
+import { Bird, BirdSchema } from './schemas/bird.schema';
+
+@Module({
+    imports: [
+        MongooseModule.forFeature([{ name: Bird.name, schema: BirdSchema }])
+    ],
+    controllers: [BirdsController],
+    providers: [BirdsService],
+})
+export class BirdsModule { }

--- a/tests/src/birds/birds.service.ts
+++ b/tests/src/birds/birds.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { CreateBirdDto } from './dto/create-bird.dto';
+import { Bird } from './schemas/bird.schema';
+
+@Injectable()
+export class BirdsService {
+    constructor(
+        @InjectModel(Bird.name) private readonly birdModel: Model<Bird>
+    ) { }
+
+    async create(dto: CreateBirdDto): Promise<Bird> {
+        const bird = new this.birdModel(dto);
+        return bird.save();
+    }
+
+    async findAll(): Promise<Bird[]> {
+        return this.birdModel.find().exec();
+    }
+}

--- a/tests/src/birds/dto/create-bird.dto.ts
+++ b/tests/src/birds/dto/create-bird.dto.ts
@@ -1,0 +1,5 @@
+export class CreateBirdDto {
+    readonly name: string;
+    readonly age: number;
+    readonly breed: string;
+}

--- a/tests/src/birds/schemas/bird.schema.ts
+++ b/tests/src/birds/schemas/bird.schema.ts
@@ -1,0 +1,16 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema()
+export class Bird extends Document {
+    @Prop()
+    name: string;
+
+    @Prop()
+    age: number;
+
+    @Prop()
+    breed: string;
+}
+
+export const BirdSchema = SchemaFactory.createForClass(Bird);


### PR DESCRIPTION
Fix for #27 

This PR adds `skipTenantCheck` option to `TenancyModuleOptions`. If `skipTenantCheck` is true for a request, tenant database connection will be bypassed. 

As in the example below, the tenant DB connection will be bypassed for all `/birds*` routes.

 ```ts
TenancyModule.forRoot({
    tenantIdentifier: 'X-TenantId',
    options: {},
    uri: (tenantId: string) => `mongodb://localhost/tenant-${tenantId}`,
    skipTenantCheck: (req) => req.route.path.match(/^\/birds*/) != null,
})
```