### PR TITLE
Added support for discriminators

### DIFF
--- a/lib/interfaces/model-definition.interface.ts
+++ b/lib/interfaces/model-definition.interface.ts
@@ -1,7 +1,14 @@
-import { Schema } from 'mongoose';
+import { DiscriminatorOptions, ObjectId, Schema } from 'mongoose';
+
+export type Discriminator = {
+  name: string;
+  schema: Schema;
+  value?: string | number | ObjectId | DiscriminatorOptions;
+};
 
 export interface ModelDefinition {
   name: string;
   schema: Schema;
   collection?: string;
+  discriminators?: Discriminator[];
 }

--- a/tests/e2e/animal-tenancy.spec.ts
+++ b/tests/e2e/animal-tenancy.spec.ts
@@ -1,0 +1,134 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { Server } from 'http';
+import * as request from 'supertest';
+import { AnimalType } from '../src/animals/dto/animal-type.enum';
+import { CreateMaineCoonDto } from '../src/animals/dto/create-maine-coon.dto';
+import { CreateBeagleDto } from '../src/animals/dto/create-beagle.dto';
+import { AppModule } from '../src/app.module';
+
+describe('AnimalTenancy', () => {
+  let server: Server;
+  let app: INestApplication;
+  const dogs = generateDogs();
+  const cats = generateCats();
+  const TENANT_HEADER = 'X-TENANT-ID';
+  const DOG_CLUB = 'dog-club';
+  const CAT_CLUB = 'cat-club';
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = module.createNestApplication();
+    server = app.getHttpServer();
+    await app.init();
+
+    await cleanupTenantDb(CAT_CLUB);
+    await cleanupTenantDb(DOG_CLUB);
+
+    for (const dog of dogs) {
+      await request(server)
+        .post('/animals')
+        .set(TENANT_HEADER, DOG_CLUB)
+        .send(dog)
+        .expect(201);
+    }
+
+    for (const cat of cats) {
+      await request(server)
+        .post('/animals')
+        .set(TENANT_HEADER, CAT_CLUB)
+        .send(cat)
+        .expect(201);
+    }
+  });
+
+  it(`each animal type must have all relevant fields`, (done) => {
+    request(server)
+      .get(`/animals`)
+      .set(TENANT_HEADER, DOG_CLUB)
+      .expect(200, (_err, { body }) => {
+        body.forEach(({ animalType, isMajestic, isGood }) => {
+          expect(animalType).toBe(AnimalType.BEAGLE);
+          expect(isGood).toBe(true);
+          expect(isMajestic).toBe(undefined);
+        });
+
+        done();
+      });
+    request(server)
+      .get(`/animals`)
+      .set(TENANT_HEADER, CAT_CLUB)
+      .expect(200, (_err, { body }) => {
+        body.forEach(({ animalType, isMajestic, isGood }) => {
+          expect(animalType).toBe(AnimalType.MAINE_COON);
+          expect(isMajestic).toBe(true);
+          expect(isGood).toBe(undefined);
+        });
+
+        done();
+      });
+  });
+
+  it(`dog-club tenant should see only dogs`, (done) => {
+    request(server)
+      .get(`/animals`)
+      .set(TENANT_HEADER, DOG_CLUB)
+      .expect(200, (_err, { body }) => {
+        expect(body).toHaveLength(3);
+        body.forEach(({ animalType }) => {
+          expect(animalType).toBe(AnimalType.BEAGLE);
+        });
+
+        done();
+      });
+  });
+
+  it(`cat-club tenant should see only cats`, (done) => {
+    request(server)
+      .get(`/animals`)
+      .set(TENANT_HEADER, CAT_CLUB)
+      .expect(200, (_err, { body }) => {
+        expect(body).toHaveLength(3);
+        body.forEach(({ animalType }) => {
+          expect(animalType).toBe(AnimalType.MAINE_COON);
+        });
+
+        done();
+      });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  async function cleanupTenantDb(tenantId: string) {
+    return request(server).delete(`/animals`).set(TENANT_HEADER, tenantId);
+  }
+});
+
+function generateCats(count = 3): CreateMaineCoonDto[] {
+  return Array(count)
+    .fill(0)
+    .map((_, i) => ({
+      animalType: AnimalType.MAINE_COON,
+      age: i,
+      breed: 'Maine coon',
+      name: `Furrball ${i}`,
+      isMajestic: true,
+    }));
+}
+
+function generateDogs(count = 3): CreateBeagleDto[] {
+  return Array(count)
+    .fill(0)
+    .map((_, i) => ({
+      animalType: AnimalType.BEAGLE,
+      age: i,
+      breed: 'Beagle',
+      name: `Fluffball ${i}`,
+      isGood: true,
+    }));
+}

--- a/tests/src/animals/animals.controller.ts
+++ b/tests/src/animals/animals.controller.ts
@@ -1,0 +1,49 @@
+import { Body, Controller, Delete, Get, Post } from '@nestjs/common';
+import { BeaglesService } from './beagles.service';
+import { AnimalType } from './dto/animal-type.enum';
+import { AnimalsDto, CreateAnimalDto } from './dto/composite-dtos';
+import { CreateBeagleDto } from './dto/create-beagle.dto';
+import { CreateMaineCoonDto } from './dto/create-maine-coon.dto';
+import { MaineCoonsService } from './maine-coons.service';
+
+@Controller('animals')
+export class AnimalsController {
+  constructor(
+    private readonly catsService: MaineCoonsService,
+    private readonly dogsService: BeaglesService,
+  ) {}
+
+  @Post()
+  async create(@Body() createAnimalDto: CreateAnimalDto): Promise<AnimalsDto> {
+    switch (createAnimalDto.animalType) {
+      case AnimalType.MAINE_COON:
+        return this.catsService.create(createAnimalDto as CreateMaineCoonDto);
+      case AnimalType.BEAGLE:
+        return this.dogsService.create(createAnimalDto as CreateBeagleDto);
+      default:
+        throw new Error('No such animal');
+    }
+  }
+
+  @Get()
+  async findAll(): Promise<AnimalsDto[]> {
+    const promises = Promise.all([
+      this.catsService.findAll(),
+      this.dogsService.findAll(),
+    ]);
+    const results = await promises;
+    return results.reduce((acc, curr) => {
+      acc.push(...curr);
+      return acc;
+    }, [] as AnimalsDto[]);
+  }
+
+  // For e2e tests cleanup
+  @Delete()
+  async removeAll(): Promise<void> {
+    await Promise.all([
+      this.catsService.removeAll(),
+      this.dogsService.removeAll(),
+    ]);
+  }
+}

--- a/tests/src/animals/animals.module.ts
+++ b/tests/src/animals/animals.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { TenancyModule } from '../../../lib';
+import { AnimalsController } from './animals.controller';
+import { BeaglesService } from './beagles.service';
+import { MaineCoonsService } from './maine-coons.service';
+import { Animal, AnimalSchema } from './schemas/animal.schema';
+import { Beagle, BeagleSchema } from './schemas/beagle.schema';
+import { MaineCoon, MaineCoonSchema } from './schemas/maine-coon.schema';
+
+@Module({
+  imports: [
+    TenancyModule.forFeature([
+      {
+        name: Animal.name,
+        schema: AnimalSchema,
+        discriminators: [
+          { name: MaineCoon.name, schema: MaineCoonSchema },
+          { name: Beagle.name, schema: BeagleSchema },
+        ],
+      },
+    ]),
+  ],
+  controllers: [AnimalsController],
+  providers: [BeaglesService, MaineCoonsService],
+})
+export class AnimalsModule {}

--- a/tests/src/animals/beagles.service.ts
+++ b/tests/src/animals/beagles.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { BeagleDto } from './dto/composite-dtos';
+import { CreateBeagleDto } from './dto/create-beagle.dto';
+import { Beagle } from './schemas/beagle.schema';
+
+@Injectable()
+export class BeaglesService {
+  constructor(
+    @InjectModel(Beagle.name) private readonly beagleModel: Model<Beagle>,
+  ) {}
+
+  async create(createDto: CreateBeagleDto): Promise<BeagleDto> {
+    const created = new this.beagleModel(createDto);
+    return created.save();
+  }
+
+  async findAll(): Promise<BeagleDto[]> {
+    return this.beagleModel.find().lean().exec();
+  }
+
+  async removeAll(): Promise<void> {
+    await this.beagleModel.deleteMany();
+  }
+}

--- a/tests/src/animals/dto/animal-type.enum.ts
+++ b/tests/src/animals/dto/animal-type.enum.ts
@@ -1,0 +1,4 @@
+export enum AnimalType {
+  BEAGLE = 'Beagle',
+  MAINE_COON = 'MaineCoon',
+}

--- a/tests/src/animals/dto/animal.dto.ts
+++ b/tests/src/animals/dto/animal.dto.ts
@@ -1,0 +1,8 @@
+import { AnimalType } from './animal-type.enum';
+
+export class AnimalDto {
+  readonly animalType: AnimalType;
+  readonly name: string;
+  readonly age: number;
+  readonly breed: string;
+}

--- a/tests/src/animals/dto/composite-dtos.ts
+++ b/tests/src/animals/dto/composite-dtos.ts
@@ -1,0 +1,16 @@
+import { AnimalDto } from './animal.dto';
+import { CreateMaineCoonDto } from './create-maine-coon.dto';
+import { CreateBeagleDto } from './create-beagle.dto';
+
+export type CreateAnimalDto = CreateBeagleDto | CreateMaineCoonDto;
+
+export interface MaineCoonDto extends AnimalDto {
+  isMajestic: boolean;
+  isGood?: never;
+}
+export interface BeagleDto extends AnimalDto {
+  isGood: boolean;
+  isMajestic?: never;
+}
+
+export type AnimalsDto = BeagleDto | MaineCoonDto;

--- a/tests/src/animals/dto/create-beagle.dto.ts
+++ b/tests/src/animals/dto/create-beagle.dto.ts
@@ -1,0 +1,7 @@
+import { AnimalType } from './animal-type.enum';
+import { AnimalDto } from './animal.dto';
+
+export class CreateBeagleDto extends AnimalDto {
+  readonly animalType: AnimalType = AnimalType.BEAGLE;
+  readonly isGood: true;
+}

--- a/tests/src/animals/dto/create-maine-coon.dto.ts
+++ b/tests/src/animals/dto/create-maine-coon.dto.ts
@@ -1,0 +1,7 @@
+import { AnimalType } from './animal-type.enum';
+import { AnimalDto } from './animal.dto';
+
+export class CreateMaineCoonDto extends AnimalDto {
+  readonly animalType: AnimalType = AnimalType.MAINE_COON;
+  readonly isMajestic: true;
+}

--- a/tests/src/animals/maine-coons.service.ts
+++ b/tests/src/animals/maine-coons.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { MaineCoonDto } from './dto/composite-dtos';
+import { CreateMaineCoonDto } from './dto/create-maine-coon.dto';
+import { MaineCoon } from './schemas/maine-coon.schema';
+
+@Injectable()
+export class MaineCoonsService {
+  constructor(
+    @InjectModel(MaineCoon.name)
+    private readonly maineCoonModel: Model<MaineCoon>,
+  ) {}
+
+  async create(createDto: CreateMaineCoonDto): Promise<MaineCoonDto> {
+    const created = new this.maineCoonModel(createDto);
+    return created.save();
+  }
+
+  async findAll(): Promise<MaineCoonDto[]> {
+    return this.maineCoonModel.find().lean().exec();
+  }
+
+  async removeAll(): Promise<void> {
+    await this.maineCoonModel.deleteMany();
+  }
+}

--- a/tests/src/animals/schemas/animal.schema.ts
+++ b/tests/src/animals/schemas/animal.schema.ts
@@ -1,0 +1,19 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+import { AnimalType } from '../dto/animal-type.enum';
+
+@Schema({ discriminatorKey: 'animalType' })
+export class Animal extends Document {
+  animalType: AnimalType;
+
+  @Prop()
+  name: string;
+
+  @Prop({ type: Number })
+  age: number;
+
+  @Prop()
+  breed: string;
+}
+
+export const AnimalSchema = SchemaFactory.createForClass(Animal);

--- a/tests/src/animals/schemas/beagle.schema.ts
+++ b/tests/src/animals/schemas/beagle.schema.ts
@@ -1,0 +1,10 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Animal } from './animal.schema';
+
+@Schema()
+export class Beagle extends Animal {
+  @Prop({ type: Boolean })
+  isGood: boolean;
+}
+
+export const BeagleSchema = SchemaFactory.createForClass(Beagle);

--- a/tests/src/animals/schemas/maine-coon.schema.ts
+++ b/tests/src/animals/schemas/maine-coon.schema.ts
@@ -1,0 +1,10 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Animal } from './animal.schema';
+
+@Schema()
+export class MaineCoon extends Animal {
+  @Prop({ type: Boolean })
+  isMajestic: boolean;
+}
+
+export const MaineCoonSchema = SchemaFactory.createForClass(MaineCoon);

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -1,19 +1,21 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { TenancyModule } from '../../lib';
+import { AnimalsModule } from './animals/animals.module';
 import { CatsModule } from './cats/cats.module';
 import { DogsModule } from './dogs/dogs.module';
 
 @Module({
-    imports: [
-        MongooseModule.forRoot('mongodb://localhost:27017/test'),
-        TenancyModule.forRoot({
-            tenantIdentifier: 'X-TENANT-ID',
-            options: () => { },
-            uri: (tenantId: string) => `mongodb://localhost/test-tenant-${tenantId}`,
-        }),
-        CatsModule,
-        DogsModule,
-    ],
+  imports: [
+    MongooseModule.forRoot('mongodb://localhost:27017/test'),
+    TenancyModule.forRoot({
+      tenantIdentifier: 'X-TENANT-ID',
+      options: () => {},
+      uri: (tenantId: string) => `mongodb://localhost/test-tenant-${tenantId}`,
+    }),
+    CatsModule,
+    DogsModule,
+    AnimalsModule,
+  ],
 })
-export class AppModule { }
+export class AppModule {}


### PR DESCRIPTION
I've picked up this issue(https://github.com/needle-innovision/nestjs-tenancy/issues/31) and continued the work that was done here(https://github.com/needle-innovision/nestjs-tenancy/compare/master...feature/mongoose-discriminators).

e2e tests:
<img width="574" alt="image" src="https://github.com/needle-innovision/nestjs-tenancy/assets/994443/c7bc5a0b-0367-45d1-bf51-e345dddf0630">

In the test project I'm using a `MaineCoon` and `Beagle` models, I wanted to use `Dog` and `Cat`, but they would clash with the models provided by `DogModule` and `CatModule`.